### PR TITLE
fix(types): allow dict-style order in query request

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -73,6 +73,7 @@ def query_data(cube: cube_http.Client):
                         }
                     ],
                     "limit": 10,
+                    "order": [{"tasks.count": "desc"}],
                 }
             }
         )

--- a/src/cube_http/types/v1/load_request.py
+++ b/src/cube_http/types/v1/load_request.py
@@ -74,7 +74,7 @@ class V1LoadRequestQuery(TypedDict):
     timeDimensions: NotRequired[list[V1LoadRequestQueryTimeDimension]]
     """List of time dimensions to be used in the query."""
 
-    order: NotRequired[list[list[str]]]
+    order: NotRequired[list[list[str]] | list[dict[str, str]]]
     """Ordering criteria for the query, specified as a dictionary of measures 
     or dimensions with `asc` or `desc` values."""
 


### PR DESCRIPTION
Order can be either:

```json
{
  "order": [["tasks.count", "desc"]]
}
```

Or they can be:

```json
{
  "order": [{ "tasks.count": "desc" }]
}
```
