### PR TITLE
fix(types): response query segments can be dict

### DIFF
--- a/docker/model/cubes/cases.yml
+++ b/docker/model/cubes/cases.yml
@@ -3,6 +3,10 @@ cubes:
     sql_table: public.cases
     data_source: default
 
+    # https://github.com/mharrisb1/cube-http-client/issues/14
+    access_policy:
+      - role: "foobar"
+
     joins:
       - name: accounts
         sql: "{CUBE}.account_id = {accounts}.id"

--- a/src/cube_http/types/v1/load_response.py
+++ b/src/cube_http/types/v1/load_response.py
@@ -97,7 +97,7 @@ class V1LoadRequestQuery(BaseModel):
         default=None, description="List of dimensions to be queried."
     )
 
-    segments: list[str] | None = Field(
+    segments: list[str] | list[dict[str, Any]] | None = Field(
         default=None,
         description="List of segments to be used in the query. "
         "A segment is a named filter defined in the data model.",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,8 +1,6 @@
-from typing import List
-
 from cube_http.types.v1 import V1LoadRequestQuery
 
-TEST_QUERIES: List[V1LoadRequestQuery] = [
+TEST_QUERIES: list[V1LoadRequestQuery] = [
     {
         "measures": ["accounts.count"],
     },


### PR DESCRIPTION
Closes [#14: Segments with rlsAccessDenied breaks the lib](https://github.com/mharrisb1/cube-http-client/issues/14)
